### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,7 +517,7 @@ LINUXINCLUDE    := \
 		$(USERINCLUDE)
 
 KBUILD_AFLAGS   := -D__ASSEMBLY__ -fno-PIE
-KBUILD_CFLAGS   := -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs \
+KBUILD_CFLAGS   := -std=gnu11 -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs \
 		   -fno-strict-aliasing -fno-common -fshort-wchar -fno-PIE \
 		   -Werror=implicit-function-declaration -Werror=implicit-int \
 		   -Werror=return-type -Wno-format-security \


### PR DESCRIPTION
Title: C Standard Used for Kernel Compilation

Summary
-------
To compile the kernel tree in a reproducible and compatible way with internal headers, the compiler option -std=gnu11 is enforced.

Motivation
----------
Newer compilers may default to more recent C standards (e.g., C2x/C23). These versions can introduce lexical changes (e.g., making 'bool' or 'false' reserved keywords) that conflict with kernel typedefs and definitions, causing compilation errors.

Decision
--------
We set `-std=gnu11` in `KBUILD_CFLAGS` (top-level Makefile) to:
  * maintain compatibility with GNU extensions used by the kernel;
  * prevent reserved keywords introduced in later standards;
  * ensure consistent behavior across different toolchains.

How to Apply
------------
- Permanent change: edit the top-level `Makefile` and add: `KBUILD_CFLAGS += -std=gnu11`

- Temporary build/test: `make KCFLAGS=-std=gnu11`

Notes
-----
This option affects only the build process and does not modify the kernel source code.
Apply this change to the Makefile of any branch as needed.

EDIT: This change may also be necessary in lower level Makefiles such as `drivers/firmware/efi/Makefile`, `drivers/firmware/efi/libstub/Makefile` and any other Makefile that overrides `KBUILD_CFLAGS`